### PR TITLE
Update README.rdoc

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -131,7 +131,7 @@ You can generate SVG and store it to file
   img.line(0, 0, 100, 100)
   
 
-  File.open("test.svg", w") do |f|
+  File.open("test.svg", "w") do |f|
     img.write(f)
   end
 


### PR DESCRIPTION
Syntax typo fix:  Example code was missing an opening quote symbol before the w in this line: File.open("test.svg", w") do |f|.